### PR TITLE
Get CI Working

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,12 +22,20 @@ jobs:
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.4.6
+      - uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
 
       - name: Install dependencies
         run: |
           sudo apt-get install libpq-dev
           gem install bundler
-          bundle install
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+          bundle update --jobs 4 --retry 3
 
       - name: Run tests
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.4.9
+          ruby-version: 2.4.6
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: Run Tests
+
+on:
+  push:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:10.8
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ''
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        ports:
+          - 5432/tcp
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.4.9
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install libpq-dev
+          gem install bundler
+          bundle install
+
+      - name: Run tests
+        env:
+          DATABASE_URL: postgres://postgres@localhost:${{ job.services.postgres.ports[5432] }}/
+        run: |
+          bundle exec rspec

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:2.4-alpine
+
+RUN apk add --no-cache \
+  build-base \
+  bash \
+  curl \
+  git \
+  libffi-dev \
+  postgresql-dev \
+  && mkdir /usr/src/gem
+
+WORKDIR /usr/src/gem
+
+COPY . ./
+
+RUN gem install bundler
+RUN bundle install
+
+ENTRYPOINT ["/bin/bash", "-l", "-c"]

--- a/README.md
+++ b/README.md
@@ -477,3 +477,12 @@ end
   some_complex_feature: true
 }
 ```
+
+### Contributing
+
+Running the tests:
+
+```
+docker-compose build
+docker-compose run --rm tests "bundle exec rspec"
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  postgres:
+    image: postgres:9.6
+    environment:
+      POSTGRES_USER: 'postgres'
+      POSTGRES_PASSWORD: ''
+
+  tests:
+    build:
+      context: ./
+    depends_on:
+      - postgres
+    environment:
+      DATABASE_URL: postgres://postgres@postgres/

--- a/featuring.gemspec
+++ b/featuring.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ActionSprout/featuring"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = '>= 2.4.9'
+  spec.required_ruby_version = '>= 2.4.6'
 
   root_files = %w[
     featuring.gemspec

--- a/spec/featuring/persistence/activerecord/database.yml
+++ b/spec/featuring/persistence/activerecord/database.yml
@@ -1,5 +1,0 @@
-test:
-  adapter: postgresql
-  host: localhost
-  port: 5432
-  database: featuring

--- a/spec/featuring/persistence/activerecord/helpers.rb
+++ b/spec/featuring/persistence/activerecord/helpers.rb
@@ -64,7 +64,7 @@ RSpec.shared_context :activerecord do
 
     unless ActiveRecord::Base.connected?
       ActiveRecord::Base.establish_connection(
-        YAML.load(ERB.new(File.read("./spec/featuring/persistence/activerecord/database.yml")).result)["test"]
+        ENV["DATABASE_URL"]
       )
     end
   end


### PR DESCRIPTION
Runs CI on Github Actions. I had to set the minimum Ruby version to 2.4.6 (from 2.4.9) because Github Actions doesn't support the latest release. This seems fine though.