### PR TITLE
Replace arel query building with update all

### DIFF
--- a/lib/featuring/persistence/activerecord.rb
+++ b/lib/featuring/persistence/activerecord.rb
@@ -58,17 +58,10 @@ module Featuring
 
         # @api private
         def update(target, **features)
-          target.feature_flag_model.connection.execute(build_update_sql(target.feature_flag_model.table_name, target, **features))
-        end
-
-        private def build_update_sql(table_name, target, **features)
-          table = Arel::Table.new(table_name)
-          update = Arel::UpdateManager.new(table.engine)
-          update.table(table)
-          update.set(Arel::Nodes::SqlLiteral.new("metadata = metadata || '#{features.to_json}'"))
-          update.where(table[:flaggable_type].eq(target.class))
-          update.where(table[:flaggable_id].eq(target.id))
-          update.to_sql
+          target.feature_flag_model.where(
+            flaggable_type: target.class.name,
+            flaggable_id: target.id,
+          ).update_all("metadata = metadata || '#{features.to_json}'")
         end
       end
     end

--- a/lib/featuring/persistence/adapter.rb
+++ b/lib/featuring/persistence/adapter.rb
@@ -110,7 +110,7 @@ module Featuring
         #   => true
         #
         def set(feature, value)
-          create_or_update_feature_flags(feature => !!value)
+          create_or_update_feature_flags(feature.to_sym => !!value)
         end
 
         # Enables a feature flag.
@@ -128,7 +128,7 @@ module Featuring
         #   => true
         #
         def enable(feature)
-          create_or_update_feature_flags(feature => true)
+          create_or_update_feature_flags(feature.to_sym => true)
         end
 
         # Disables a feature flag.
@@ -146,7 +146,7 @@ module Featuring
         #   => false
         #
         def disable(feature)
-          create_or_update_feature_flags(feature => false)
+          create_or_update_feature_flags(feature.to_sym => false)
         end
 
         # Reloads feature flag values for the object.

--- a/spec/featuring/persistence/activerecord/defaults_spec.rb
+++ b/spec/featuring/persistence/activerecord/defaults_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe "persisting the default value for a feature flag on an activereco
     end
 
     it "sets by updating the existing feature flag record" do
-      expect(feature_flag_model_connection).to have_received(:execute).with(
-        "UPDATE \"feature_flags\" SET metadata = metadata || '{\"some_feature\":true}' WHERE \"feature_flags\".\"flaggable_type\" = 'ModelWithFeatures' AND \"feature_flags\".\"flaggable_id\" = 123"
+      expect(feature_flag_dataset).to have_received(:update_all).with(
+        "metadata = metadata || '{\"some_feature\":true}'"
       )
     end
   end
@@ -108,8 +108,8 @@ RSpec.describe "persisting the default value for a feature flag on an activereco
     end
 
     it "sets by updating the existing feature flag record" do
-      expect(feature_flag_model_connection).to have_received(:execute).with(
-        "UPDATE \"feature_flags\" SET metadata = metadata || '{\"some_feature\":true}' WHERE \"feature_flags\".\"flaggable_type\" = 'ModelWithFeatures' AND \"feature_flags\".\"flaggable_id\" = 123"
+      expect(feature_flag_dataset).to have_received(:update_all).with(
+        "metadata = metadata || '{\"some_feature\":true}'"
       )
     end
   end

--- a/spec/featuring/persistence/activerecord/disabling_spec.rb
+++ b/spec/featuring/persistence/activerecord/disabling_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe "disabling a feature flag on an activerecord model" do
     end
 
     it "disables by updating the existing feature flag record" do
-      expect(feature_flag_model_connection).to have_received(:execute).with(
-        "UPDATE \"feature_flags\" SET metadata = metadata || '{\"some_feature\":false}' WHERE \"feature_flags\".\"flaggable_type\" = 'ModelWithFeatures' AND \"feature_flags\".\"flaggable_id\" = 123"
+      expect(feature_flag_dataset).to have_received(:update_all).with(
+        "metadata = metadata || '{\"some_feature\":false}'"
       )
     end
   end
@@ -54,8 +54,8 @@ RSpec.describe "disabling a feature flag on an activerecord model" do
     end
 
     it "disables by updating the existing feature flag record" do
-      expect(feature_flag_model_connection).to have_received(:execute).with(
-        "UPDATE \"feature_flags\" SET metadata = metadata || '{\"some_feature\":false}' WHERE \"feature_flags\".\"flaggable_type\" = 'ModelWithFeatures' AND \"feature_flags\".\"flaggable_id\" = 123"
+      expect(feature_flag_dataset).to have_received(:update_all).with(
+        "metadata = metadata || '{\"some_feature\":false}'"
       )
     end
   end

--- a/spec/featuring/persistence/activerecord/enabling_spec.rb
+++ b/spec/featuring/persistence/activerecord/enabling_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe "enabling a feature flag on an activerecord model" do
     end
 
     it "enables by updating the existing feature flag record" do
-      expect(feature_flag_model_connection).to have_received(:execute).with(
-        "UPDATE \"feature_flags\" SET metadata = metadata || '{\"some_feature\":true}' WHERE \"feature_flags\".\"flaggable_type\" = 'ModelWithFeatures' AND \"feature_flags\".\"flaggable_id\" = 123"
+      expect(feature_flag_dataset).to have_received(:update_all).with(
+        "metadata = metadata || '{\"some_feature\":true}'"
       )
     end
   end
@@ -54,8 +54,8 @@ RSpec.describe "enabling a feature flag on an activerecord model" do
     end
 
     it "enables by updating the existing feature flag record" do
-      expect(feature_flag_model_connection).to have_received(:execute).with(
-        "UPDATE \"feature_flags\" SET metadata = metadata || '{\"some_feature\":true}' WHERE \"feature_flags\".\"flaggable_type\" = 'ModelWithFeatures' AND \"feature_flags\".\"flaggable_id\" = 123"
+      expect(feature_flag_dataset).to have_received(:update_all).with(
+        "metadata = metadata || '{\"some_feature\":true}'"
       )
     end
   end

--- a/spec/featuring/persistence/activerecord/helpers.rb
+++ b/spec/featuring/persistence/activerecord/helpers.rb
@@ -9,15 +9,15 @@ RSpec.shared_context :activerecord do
   let!(:feature_flag_model) {
     feature_flag_model = Class.new do
       def self.find_by(*); end
-
-      def self.table_name
-        "feature_flags"
-      end
     end
 
     stub_const "FeatureFlag", feature_flag_model
 
     feature_flag_model
+  }
+
+  let(:feature_flag_dataset) {
+    double(:feature_flag_dataset)
   }
 
   let(:features) {
@@ -64,9 +64,16 @@ RSpec.shared_context :activerecord do
 
     unless ActiveRecord::Base.connected?
       ActiveRecord::Base.establish_connection(
-        ENV["DATABASE_URL"]
+        ENV["DATABASE_URL"] || "postgres://postgres@localhost/"
       )
     end
+
+    allow(feature_flag_model).to receive(:where).with(
+      flaggable_type: 'ModelWithFeatures',
+      flaggable_id: 123,
+    ).and_return(feature_flag_dataset)
+
+    allow(feature_flag_dataset).to receive(:update_all)
   end
 end
 

--- a/spec/featuring/persistence/activerecord/resetting_spec.rb
+++ b/spec/featuring/persistence/activerecord/resetting_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe "resetting the value for a feature flag on an activerecord model"
     end
 
     it "removes the persisted value with an update" do
-      expect(feature_flag_model_connection).to have_received(:execute).with(
-        "UPDATE \"feature_flags\" SET metadata = metadata || '{\"another_feature\":false}' WHERE \"feature_flags\".\"flaggable_type\" = 'ModelWithFeatures' AND \"feature_flags\".\"flaggable_id\" = 123"
+      expect(feature_flag_dataset).to have_received(:update_all).with(
+        "metadata = metadata || '{\"another_feature\":false}'"
       )
     end
   end

--- a/spec/featuring/persistence/activerecord/setting_spec.rb
+++ b/spec/featuring/persistence/activerecord/setting_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe "setting a feature flag on an activerecord model" do
     end
 
     it "sets by updating the existing feature flag record" do
-      expect(feature_flag_model_connection).to have_received(:execute).with(
-        "UPDATE \"feature_flags\" SET metadata = metadata || '{\"some_feature\":true}' WHERE \"feature_flags\".\"flaggable_type\" = 'ModelWithFeatures' AND \"feature_flags\".\"flaggable_id\" = 123"
+      expect(feature_flag_dataset).to have_received(:update_all).with(
+        "metadata = metadata || '{\"some_feature\":true}'"
       )
     end
   end
@@ -65,8 +65,8 @@ RSpec.describe "setting a feature flag on an activerecord model" do
     end
 
     it "sets by updating the existing feature flag record" do
-      expect(feature_flag_model_connection).to have_received(:execute).with(
-        "UPDATE \"feature_flags\" SET metadata = metadata || '{\"some_feature\":true}' WHERE \"feature_flags\".\"flaggable_type\" = 'ModelWithFeatures' AND \"feature_flags\".\"flaggable_id\" = 123"
+      expect(feature_flag_dataset).to have_received(:update_all).with(
+        "metadata = metadata || '{\"some_feature\":true}'"
       )
     end
   end

--- a/spec/featuring/persistence/activerecord/transaction_spec.rb
+++ b/spec/featuring/persistence/activerecord/transaction_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe "persisting multiple feature flags on an activerecord model" do
     end
 
     it "updates the flags at once" do
-      expect(feature_flag_model_connection).to have_received(:execute).with(
-        "UPDATE \"feature_flags\" SET metadata = metadata || '{\"foo\":true,\"bar\":false,\"baz\":true,\"qux\":false,\"quux\":true}' WHERE \"feature_flags\".\"flaggable_type\" = 'ModelWithFeatures' AND \"feature_flags\".\"flaggable_id\" = 123"
+      expect(feature_flag_dataset).to have_received(:update_all).with(
+        "metadata = metadata || '{\"foo\":true,\"bar\":false,\"baz\":true,\"qux\":false,\"quux\":true}'"
       )
     end
   end


### PR DESCRIPTION
I hit an issue using `featuring` in an app with a newer version of `arel`, which broke updates. Avoiding `arel` altogether makes `featuring` more compatible with more versions of Rails and is simpler. Not sure why I didn't do it this way to begin with, but here we are.