### PR TITLE
Fix a handful of bugs around reset and persist

### DIFF
--- a/lib/featuring/persistence/activerecord.rb
+++ b/lib/featuring/persistence/activerecord.rb
@@ -58,10 +58,19 @@ module Featuring
 
         # @api private
         def update(target, **features)
+          scoped_dataset(target).update_all("metadata = metadata || '#{features.to_json}'")
+        end
+
+        # @api private
+        def replace(target, **features)
+          scoped_dataset(target).update_all("metadata = '#{features.to_json}'")
+        end
+
+        private def scoped_dataset(target)
           target.feature_flag_model.where(
             flaggable_type: target.class.name,
             flaggable_id: target.id,
-          ).update_all("metadata = metadata || '#{features.to_json}'")
+          )
         end
       end
     end

--- a/lib/featuring/persistence/adapter.rb
+++ b/lib/featuring/persistence/adapter.rb
@@ -68,7 +68,7 @@ module Featuring
         #   => false
         #
         def persist(feature, *args)
-          create_or_update_feature_flags(feature => public_send(:"#{feature}?", *args))
+          create_or_update_feature_flags(feature => fetch_feature_flag_value(feature, *args, raw: true))
         end
 
         # Ensures that a feature flag is *not* persisted, falling back to its default value.
@@ -228,15 +228,15 @@ module Featuring
         end
 
         # @api private
-        def fetch_feature_flag_value(name, *args)
-          if persisted?(name)
+        def fetch_feature_flag_value(name, *args, raw: false)
+          if !raw && persisted?(name)
             if feature_flag_has_block?(name)
-              persisted(name) && super
+              persisted(name) && super(name, *args)
             else
               persisted(name)
             end
           else
-            super
+            super(name, *args)
           end
         end
 

--- a/lib/featuring/persistence/adapter.rb
+++ b/lib/featuring/persistence/adapter.rb
@@ -164,7 +164,7 @@ module Featuring
         def transaction
           transaction = Transaction.new(self)
           yield transaction
-          create_or_update_feature_flags(**transaction.values)
+          create_or_update_feature_flags(__perform: :replace, **transaction.values)
         end
 
         # Returns `true` if the feature flag is persisted, optionally with the specified value.
@@ -213,9 +213,9 @@ module Featuring
           end
         end
 
-        private def create_or_update_feature_flags(**features)
+        private def create_or_update_feature_flags(__perform: :update, **features)
           if persisted?
-            feature_flag_adapter.update(@parent, **features)
+            feature_flag_adapter.public_send(__perform, @parent, **features)
 
             # Update the local persisted values to match.
             #

--- a/lib/featuring/persistence/adapter.rb
+++ b/lib/featuring/persistence/adapter.rb
@@ -222,6 +222,14 @@ module Featuring
             features.each do |feature, value|
               persisted_flags[feature] = value
             end
+
+            # Remove local feature flags if no longer present.
+            #
+            persisted_flags.each_key do |feature|
+              unless features.include?(feature.to_sym)
+                persisted_flags.delete(feature)
+              end
+            end
           else
             feature_flag_adapter.create(@parent, **features)
           end

--- a/lib/featuring/persistence/adapter.rb
+++ b/lib/featuring/persistence/adapter.rb
@@ -17,6 +17,8 @@ module Featuring
     #
     #   3. `update`: Updates feature flags for a given object.
     #
+    #   4. `replace`: Replaces feature flags for a given object.
+    #
     # See {Featuring::Persistence::ActiveRecord} for a complete example.
     #
     module Adapter
@@ -91,7 +93,7 @@ module Featuring
           if persisted?(feature)
             features = persisted_flags
             features.delete(feature)
-            feature_flag_adapter.update(@parent, **features.symbolize_keys)
+            feature_flag_adapter.replace(@parent, **features.symbolize_keys)
           end
         end
 

--- a/lib/featuring/persistence/transaction.rb
+++ b/lib/featuring/persistence/transaction.rb
@@ -66,6 +66,14 @@ module Featuring
       def disable(feature)
         @values[feature.to_sym] = false
       end
+
+      # Resets a feature flag.
+      #
+      # See {Featuring::Persistence::Adapter::Methods#reset}
+      #
+      def reset(feature)
+        @values.delete(feature.to_sym)
+      end
     end
   end
 end

--- a/lib/featuring/persistence/transaction.rb
+++ b/lib/featuring/persistence/transaction.rb
@@ -40,7 +40,7 @@ module Featuring
       # See {Featuring::Persistence::Adapter::Methods#persist}
       #
       def persist(feature, *args)
-        @values[feature.to_sym] = @features.public_send(:"#{feature}?", *args)
+        @values[feature.to_sym] = @features.fetch_feature_flag_value(feature, *args, raw: true)
       end
 
       # Sets the value for a feature flag within a transaction.

--- a/spec/featuring/persistence/activerecord/persisting_spec.rb
+++ b/spec/featuring/persistence/activerecord/persisting_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative "./helpers"
+
+RSpec.describe "persisting the default feature flag value on an activerecord model" do
+  include_context :activerecord
+
+  let(:features) {
+    Module.new do
+      extend Featuring::Declarable
+      feature :some_feature, true
+    end
+  }
+
+  def perform
+    instance.features.persist :some_feature
+  end
+
+  context "instance has no persisted feature flags" do
+    before do
+      allow(feature_flag_model).to receive(:create)
+      allow(feature_flag_model).to receive(:find_by)
+
+      perform
+    end
+
+    it "sets by creating a feature flag record" do
+      expect(feature_flag_model).to have_received(:create).with(
+        flaggable_id: instance_id,
+        flaggable_type: model.name,
+        metadata: {
+          some_feature: true
+        }
+      )
+    end
+  end
+
+  context "feature flag is already set" do
+    include_context :existing_feature_flag
+
+    let(:features) {
+      Module.new do
+        extend Featuring::Declarable
+        feature :some_feature, false
+      end
+    }
+
+    let(:existing_feature_flag_metadata) {
+      { "some_feature" => true }
+    }
+
+    before do
+      instance.features.persist :some_feature
+    end
+
+    it "sets by updating the existing feature flag record" do
+      expect(feature_flag_dataset).to have_received(:update_all).with(
+        "metadata = metadata || '{\"some_feature\":false}'"
+      )
+    end
+  end
+end

--- a/spec/featuring/persistence/activerecord/resetting_spec.rb
+++ b/spec/featuring/persistence/activerecord/resetting_spec.rb
@@ -34,14 +34,25 @@ RSpec.describe "resetting the value for a feature flag on an activerecord model"
       { some_feature: true, another_feature: false }
     }
 
+    let(:features) {
+      Module.new do
+        extend Featuring::Declarable
+        feature :some_feature, false
+      end
+    }
+
     before do
       instance.features.reset :some_feature
     end
 
     it "removes the persisted value with an update" do
       expect(feature_flag_dataset).to have_received(:update_all).with(
-        "metadata = metadata || '{\"another_feature\":false}'"
+        "metadata = '{\"another_feature\":false}'"
       )
+    end
+
+    it "updates the local values" do
+      expect(instance.features.some_feature?).to be(false)
     end
   end
 end

--- a/spec/featuring/persistence/activerecord/transaction_spec.rb
+++ b/spec/featuring/persistence/activerecord/transaction_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe "persisting multiple feature flags on an activerecord model" do
   context "feature flag is already set" do
     include_context :existing_feature_flag
 
+    let(:existing_feature_flag_metadata) {
+      {
+        foo: false,
+        bar: true,
+        baz: false,
+        qux: true,
+        quux: false,
+        corge: true
+      }
+    }
+
     before do
       perform
     end

--- a/spec/featuring/persistence/activerecord/transaction_spec.rb
+++ b/spec/featuring/persistence/activerecord/transaction_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "persisting multiple feature flags on an activerecord model" do
       end
       feature :qux
       feature :quux
+      feature :corge
     end
   }
 
@@ -25,6 +26,8 @@ RSpec.describe "persisting multiple feature flags on an activerecord model" do
       features.persist :baz, :baz
       features.disable :qux
       features.enable :quux
+      features.set :corge, true
+      features.reset :corge
     end
   end
 
@@ -60,7 +63,7 @@ RSpec.describe "persisting multiple feature flags on an activerecord model" do
 
     it "updates the flags at once" do
       expect(feature_flag_dataset).to have_received(:update_all).with(
-        "metadata = metadata || '{\"foo\":true,\"bar\":false,\"baz\":true,\"qux\":false,\"quux\":true}'"
+        "metadata = '{\"foo\":true,\"bar\":false,\"baz\":true,\"qux\":false,\"quux\":true}'"
       )
     end
   end

--- a/spec/featuring/persistence/activerecord/transaction_spec.rb
+++ b/spec/featuring/persistence/activerecord/transaction_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "persisting multiple feature flags on an activerecord model" do
       extend Featuring::Declarable
       feature :foo
       feature :bar
-      feature :baz do |value|
+      feature :baz do |value = nil|
         value == :baz
       end
       feature :qux
@@ -76,6 +76,15 @@ RSpec.describe "persisting multiple feature flags on an activerecord model" do
       expect(feature_flag_dataset).to have_received(:update_all).with(
         "metadata = '{\"foo\":true,\"bar\":false,\"baz\":true,\"qux\":false,\"quux\":true}'"
       )
+    end
+
+    it "updates the local values" do
+      expect(instance.features.foo?).to be(true)
+      expect(instance.features.bar?).to be(false)
+      expect(instance.features.baz?).to be(true)
+      expect(instance.features.qux?).to be(false)
+      expect(instance.features.quux?).to be(true)
+      expect(instance.features.corge?).to be(false)
     end
   end
 end


### PR DESCRIPTION
Fixes several bugs:

* Correctly replace existing values when resetting a feature flag.
* Add support for resets within a transaction (I missed this when adding resets).
* Ignore the current persisted value when persisting the default value for a flag.
  * This one is hard to grok but maybe the test cases I introduced clarify.
* Remove feature flags from the local cache when reset in a transaction.